### PR TITLE
feat(gui): add uninstall button

### DIFF
--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -6,7 +6,6 @@ use spicy_launcher_core::github::GitHubClient;
 use spicy_launcher_core::release::Release;
 use spicy_launcher_core::storage::LocalStorage;
 use spicy_launcher_core::tracker::{ProgressEvent, ProgressTracker};
-use std::fs;
 
 pub struct App {
     client: GitHubClient,
@@ -120,7 +119,7 @@ impl App {
     pub async fn uninstall(&mut self, version: Option<String>) -> Result<()> {
         let releases = self.get_releases().await?;
         let release = self.find_version(version, releases)?;
-        let install_path = self.storage.data_dir.join(&release.version);
+        let install_path = self.storage.version_path(&release.version);
         if install_path.exists() {
             log::debug!("Removing {:?}", install_path);
             self.progress_bar.set_message(format!(
@@ -128,7 +127,7 @@ impl App {
                 "Uninstalling".green(),
                 &release.version
             ));
-            fs::remove_dir_all(install_path)?;
+            self.storage.remove_version(&release.version)?;
             self.progress_bar.finish();
             log::info!("{} is uninstalled.", &release.version);
         } else {

--- a/core/src/archive/zip.rs
+++ b/core/src/archive/zip.rs
@@ -13,7 +13,7 @@ pub fn extract<Tracker: ProgressTracker>(
 ) -> Result<()> {
     let source = File::open(target)?;
     if !target_dir.exists() {
-        fs::create_dir(&target_dir)?;
+        fs::create_dir(target_dir)?;
     }
     let mut archive = ZipArchive::new(source)?;
     let total = archive.len().try_into()?;
@@ -50,7 +50,7 @@ pub fn extract<Tracker: ProgressTracker>(
         } else {
             if let Some(parent) = output_path.parent() {
                 if !parent.exists() {
-                    fs::create_dir_all(&parent)?;
+                    fs::create_dir_all(parent)?;
                 }
             }
             let mut outfile = File::create(&output_path)?;
@@ -96,7 +96,7 @@ fn has_toplevel<S: Read + Seek>(archive: &mut ZipArchive<S>) -> Result<bool> {
 fn set_unix_mode(file: &zip::read::ZipFile, output_path: &Path) -> io::Result<()> {
     if let Some(mode) = file.unix_mode() {
         fs::set_permissions(
-            &output_path,
+            output_path,
             std::os::unix::fs::PermissionsExt::from_mode(mode),
         )?
     }

--- a/core/src/storage.rs
+++ b/core/src/storage.rs
@@ -28,12 +28,19 @@ impl LocalStorage {
         Ok(Self { temp_dir, data_dir })
     }
 
+    /// Get the filesystem path storing the specified version of the game.
+    ///
+    /// > **Note:** The path may or may not exist.
+    pub fn version_path(&self, release_version: &str) -> PathBuf {
+        self.data_dir.join(release_version)
+    }
+
+    /// Remove the specified version from the filesystem, if it is installed.
     pub fn remove_version(&self, release_version: &str) -> Result<()> {
-        let target_dir = &self.data_dir.join(release_version);
+        let target_dir = self.version_path(release_version);
         if target_dir.exists() {
             std::fs::remove_dir_all(target_dir)?;
         }
-
         Ok(())
     }
 

--- a/core/src/storage.rs
+++ b/core/src/storage.rs
@@ -22,7 +22,7 @@ impl LocalStorage {
             .join(DATA_DIR);
         for path in &[&temp_dir, &data_dir] {
             if !path.exists() {
-                fs::create_dir(&path)?;
+                fs::create_dir(path)?;
             }
         }
         Ok(Self { temp_dir, data_dir })
@@ -66,14 +66,14 @@ impl LocalStorage {
     }
 
     pub fn launch_game(&self, version: &str) -> Result<()> {
-        let binary_path = &self.data_dir.join(&version).join(BINARY_NAME);
+        let binary_path = &self.data_dir.join(version).join(BINARY_NAME);
         log::debug!("Launching: {:?}", binary_path);
         Command::new(
             binary_path
                 .to_str()
                 .ok_or_else(|| Error::Utf8(String::from("path contains invalid characters")))?,
         )
-        .current_dir(self.data_dir.join(&version))
+        .current_dir(self.data_dir.join(version))
         .spawn()?;
         Ok(())
     }

--- a/core/src/storage.rs
+++ b/core/src/storage.rs
@@ -28,6 +28,15 @@ impl LocalStorage {
         Ok(Self { temp_dir, data_dir })
     }
 
+    pub fn remove_version(&self, release_version: &str) -> Result<()> {
+        let target_dir = &self.data_dir.join(release_version);
+        if target_dir.exists() {
+            std::fs::remove_dir_all(target_dir)?;
+        }
+
+        Ok(())
+    }
+
     pub fn extract_archive<Tracker: ProgressTracker>(
         &self,
         asset: &Asset,

--- a/gui/src-tauri/src/app.rs
+++ b/gui/src-tauri/src/app.rs
@@ -29,8 +29,8 @@ impl App {
     }
 
     pub async fn uninstall(&self, version: &str) -> Result<()> {
+        log::info!("Uninstalling {}...", version);
         self.storage.remove_version(version)?;
-
         Ok(())
     }
 

--- a/gui/src-tauri/src/app.rs
+++ b/gui/src-tauri/src/app.rs
@@ -28,6 +28,12 @@ impl App {
         Ok(releases)
     }
 
+    pub async fn uninstall(&self, version: &str) -> Result<()> {
+        self.storage.remove_version(version)?;
+
+        Ok(())
+    }
+
     pub async fn install(&self, version: &str, progress_bar: &mut ProgressBar) -> Result<()> {
         log::info!("Installing {}...", version);
         let versions = self.get_versions().await?;

--- a/gui/src-tauri/src/main.rs
+++ b/gui/src-tauri/src/main.rs
@@ -21,6 +21,15 @@ async fn get_versions(app: State<'_, App>) -> Result<Vec<Release>, ()> {
 }
 
 #[tauri::command]
+async fn uninstall(version: String, app: State<'_, App>, _window: Window) -> Result<(), Error> {
+    app.uninstall(&version)
+        .await
+        .expect("cannot uninstall version");
+
+    Ok(())
+}
+
+#[tauri::command]
 async fn install(version: String, app: State<'_, App>, window: Window) -> Result<(), Error> {
     let mut progress_bar = ProgressBar { window };
     app.install(&version, &mut progress_bar)
@@ -52,7 +61,12 @@ fn main() -> AppResult<()> {
     let app = App::new()?;
     tauri::Builder::default()
         .manage(app)
-        .invoke_handler(tauri::generate_handler![get_versions, install, launch])
+        .invoke_handler(tauri::generate_handler![
+            get_versions,
+            uninstall,
+            install,
+            launch
+        ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
     Ok(())

--- a/gui/src-tauri/src/main.rs
+++ b/gui/src-tauri/src/main.rs
@@ -25,7 +25,6 @@ async fn uninstall(version: String, app: State<'_, App>, _window: Window) -> Res
     app.uninstall(&version)
         .await
         .expect("cannot uninstall version");
-
     Ok(())
 }
 

--- a/gui/src/components/LinkRenderer.svelte
+++ b/gui/src/components/LinkRenderer.svelte
@@ -3,4 +3,4 @@
   export let title = undefined;
 </script>
 
-<a {href} {title} target="_blank"><slot /></a>
+<a {href} {title} target="_blank" rel="noreferrer"><slot /></a>

--- a/gui/src/components/Sidebar.svelte
+++ b/gui/src/components/Sidebar.svelte
@@ -112,13 +112,20 @@
   {/if}
 
   <nav class="social">
-    <a target="_blank" href="https://twitter.com/spicylobsterfam"
+    <a
+      target="_blank"
+      rel="noreferrer"
+      href="https://twitter.com/spicylobsterfam"
       ><i class="nes-icon twitter" /></a
     >
-    <a target="_blank" href="https://github.com/spicylobstergames">
+    <a
+      target="_blank"
+      rel="noreferrer"
+      href="https://github.com/spicylobstergames"
+    >
       <i class="nes-icon github " /></a
     >
-    <a target="_blank" href="https://discord.gg/rKmE4HTD">
+    <a target="_blank" rel="noreferrer" href="https://discord.gg/rKmE4HTD">
       <i class="nes-icon discord" /></a
     >
   </nav>

--- a/gui/src/components/Sidebar.svelte
+++ b/gui/src/components/Sidebar.svelte
@@ -17,6 +17,15 @@
     versionStore.set(await invoke("get_versions"));
   });
 
+  async function uninstallSelectedVersion() {
+    await invoke("uninstall", {
+      version: selectedVersion.version,
+    });
+
+    selectedVersion.installed = false;
+    $downloadProgress.event = "Finished";
+  }
+
   $: loading = !$versionStore;
 
   $: selectedVersion = $versionStore.find(
@@ -113,14 +122,7 @@
       <button
         type="button"
         class="nes-btn is-warning play-btn"
-        on:click={() => {
-          invoke("uninstall", {
-            version: selectedVersion.version,
-          }).then(() => {
-            selectedVersion.installed = false;
-            $downloadProgress.event = "Finished";
-          });
-        }}
+        on:click={uninstallSelectedVersion}
         disabled={btnDisabled}
         class:is-disabled={btnDisabled}>Uninstall</button
       >

--- a/gui/src/components/Sidebar.svelte
+++ b/gui/src/components/Sidebar.svelte
@@ -109,6 +109,22 @@
       disabled={btnDisabled}
       class:is-disabled={btnDisabled}>{buttonText}</button
     >
+    {#if selectedVersion && selectedVersion.installed}
+      <button
+        type="button"
+        class="nes-btn is-warning play-btn"
+        on:click={() => {
+          invoke("uninstall", {
+            version: selectedVersion.version,
+          }).then(() => {
+            selectedVersion.installed = false;
+            $downloadProgress.event = "Finished";
+          });
+        }}
+        disabled={btnDisabled}
+        class:is-disabled={btnDisabled}>Uninstall</button
+      >
+    {/if}
   {/if}
 
   <nav class="social">
@@ -140,6 +156,7 @@
     background-color: white;
     height: 100vh;
     position: relative;
+    overflow: hidden;
 
     .logo {
       align-self: center;


### PR DESCRIPTION
[uninstall-button.webm](https://user-images.githubusercontent.com/25393315/198740443-86a197a7-3f3a-476c-9ae2-314cdf797415.webm)

For testing pre-release versions of the game, I was thinking we could setup CI for Jumpy to publish to a release every time we push to main. Since it'd be the same `Jumpy Developer Preview` release every time we push, overwriting the old assets, you have to be able to uninstall the old version if you want to re-download the new version.

It's the quickest way forward to get the raw functionality needed, and we can add a much better UX later