### PR TITLE
chore: Run cronjob for thetawave in cron.yml

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -16,13 +16,12 @@ jobs:
           fetch-depth: 1
 
       - name: Update
+        shell: bash
         run: |
-          for game in "jumpy" "punchy"; do
+          for game in "fishfolk/jumpy" "fishfolk/punchy" "thetawavegame/thetawave"; do
             curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-              "https://api.github.com/repos/fishfolk/${game}/releases" > "${game}.json"
+              "https://api.github.com/repos/${game}/releases" > "${game#*/}.json"
           done
-          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/repos/thetawavegame/thetawave/releases" > "thetawave.json"
 
       - name: Commit
         run: |

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -21,6 +21,8 @@ jobs:
             curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
               "https://api.github.com/repos/fishfolk/${game}/releases" > "${game}.json"
           done
+          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/thetawavegame/thetawave/releases" > "thetawave.json"
 
       - name: Commit
         run: |

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -2,19 +2,19 @@
 name = "spicy-launcher"
 version = "0.2.0"
 description = "Cross-platform launcher for Spicy Lobster games"
-authors = [ "Orhun Parmaksız <orhunparmaksiz@gmail.com>" ]
+authors = ["Orhun Parmaksız <orhunparmaksiz@gmail.com>"]
 license = "MIT OR Apache-2.0"
 default-run = "spicy-launcher"
 edition = "2021"
 build = "src/build.rs"
 
 [features]
-default = [ "custom-protocol" ]
-custom-protocol = [ "tauri/custom-protocol" ]
+default = ["custom-protocol"]
+custom-protocol = ["tauri/custom-protocol"]
 
 [dependencies]
 serde_json = "1.0.89"
-serde = { version = "1.0", features = [ "derive" ] }
+serde = { version = "1.0", features = ["derive"] }
 tauri = { version = "1.2.0", features = ["api-all"] }
 pretty_env_logger = "0.4.0"
 log = "0.4.14"

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -2,19 +2,19 @@
 name = "spicy-launcher"
 version = "0.2.0"
 description = "Cross-platform launcher for Spicy Lobster games"
-authors = ["Orhun Parmaksız <orhunparmaksiz@gmail.com>"]
+authors = [ "Orhun Parmaksız <orhunparmaksiz@gmail.com>" ]
 license = "MIT OR Apache-2.0"
 default-run = "spicy-launcher"
 edition = "2021"
 build = "src/build.rs"
 
 [features]
-default = ["custom-protocol"]
-custom-protocol = ["tauri/custom-protocol"]
+default = [ "custom-protocol" ]
+custom-protocol = [ "tauri/custom-protocol" ]
 
 [dependencies]
 serde_json = "1.0.89"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = [ "derive" ] }
 tauri = { version = "1.2.0", features = ["api-all"] }
 pretty_env_logger = "0.4.0"
 log = "0.4.14"


### PR DESCRIPTION
I'm working on adding Thetawave to the launcher. I wanted to add the curl command to the cron workflow so that I can access the release data with the github api when I add the game to the launcher.