### PR TITLE
add no prefix install option

### DIFF
--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -33,6 +33,14 @@ impl App {
             return Err(anyhow!("No releases found/installed :("));
         }
 
+        let version = version.map(|v| {
+            if !v.starts_with('v') {
+                format!("v{}", v)
+            } else {
+                v
+            }
+        });
+
         match version {
             Some(version) => releases
                 .clone()


### PR DESCRIPTION
This change resolves #46 Installing without version prefix, by checking for a lack of presence of a character at the beginning and modifying it to include it for match. Can do a follow up testing and writing for code coverage, profiling, etc. of the codebase.