### PR TITLE
 add no prefix install option

### DIFF
--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -33,21 +33,20 @@ impl App {
             return Err(anyhow!("No releases found/installed :("));
         }
 
-        let version = version.map(|v| {
-            if !v.starts_with('v') {
-                format!("v{}", v)
-            } else {
-                v
-            }
-        });
-
         match version {
-            Some(version) => releases
-                .clone()
-                .into_iter()
-                .find(|release| release.version == version)
-                .ok_or_else(|| {
-                    anyhow!(
+            Some(version) => {
+                let normalized_version = if version.starts_with('v') {
+                    version.clone()
+                } else {
+                    format!("v{}", version)
+                };
+                
+                releases
+                    .clone()
+                    .into_iter()
+                    .find(|release| release.version == normalized_version)
+                    .ok_or_else(|| {
+                        anyhow!(
                         "Version {} not found, available versions are: {}",
                         version.red(),
                         releases
@@ -62,7 +61,8 @@ impl App {
                             .join(" ")
                             .blue()
                     )
-                }),
+                })
+            }
             None => Ok(releases[0].clone()),
         }
     }

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -33,6 +33,14 @@ impl App {
             return Err(anyhow!("No releases found/installed :("));
         }
 
+        let version = version.map(|v| {
+            if !v.starts_with('v') {
+                format!("v{}", v)
+            } else {
+                v
+            }
+        });
+
         match version {
             Some(version) => releases
                 .clone()

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -40,28 +40,28 @@ impl App {
                 } else {
                     format!("v{}", version)
                 };
-                
+
                 releases
                     .clone()
                     .into_iter()
                     .find(|release| release.version == normalized_version)
                     .ok_or_else(|| {
                         anyhow!(
-                        "Version {} not found, available versions are: {}",
-                        version.red(),
-                        releases
-                            .iter()
-                            .enumerate()
-                            .map(|(i, release)| if i != releases.len() - 1 {
-                                format!("{},", release.version)
-                            } else {
-                                release.version.to_string()
-                            })
-                            .collect::<Vec<String>>()
-                            .join(" ")
-                            .blue()
-                    )
-                })
+                            "Version {} not found, available versions are: {}",
+                            version.red(),
+                            releases
+                                .iter()
+                                .enumerate()
+                                .map(|(i, release)| if i != releases.len() - 1 {
+                                    format!("{},", release.version)
+                                } else {
+                                    release.version.to_string()
+                                })
+                                .collect::<Vec<String>>()
+                                .join(" ")
+                                .blue()
+                        )
+                    })
             }
             None => Ok(releases[0].clone()),
         }


### PR DESCRIPTION
This change resolves #46  Installing without version prefix, by checking for a lack of presence of a character at the beginning and modifying it to include it for match. Can do a follow up testing and writing for code coverage, profiling, etc. of the codebase.